### PR TITLE
update alias to match renamed formula

### DIFF
--- a/Aliases/go@1.8.rb
+++ b/Aliases/go@1.8.rb
@@ -1,1 +1,1 @@
-../Formula/cockroach-go.rb
+../Formula/go.rb


### PR DESCRIPTION
Looks like the #1 moved the Formula this as pointing to?

```
$ brew install cockroachdb/go/go
==> Tapping cockroachdb/go
Cloning into '/usr/local/Homebrew/Library/Taps/cockroachdb/homebrew-go'...
...
Error: Broken alias: /usr/local/Homebrew/Library/Taps/cockroachdb/homebrew-go/Aliases/go@1.8.rb
Error: Cannot tap cockroachdb/go: invalid syntax in tap!
```